### PR TITLE
Re:VIEW 5.5 -> 5.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # https://help.github.com/en/actions/building-actions/creating-a-docker-container-action
 
 # Container image that runs your code
-FROM vvakame/review:5.5
+FROM vvakame/review:5.9
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ English is below.
 
 ## 概要
 
-[Re:VIEW](https://github.com/kmuto/review)リポジトリをビルドしてPDFやEPUBを出力するための[GitHub Action](https://github.com/features/actions)です。
+[Re:VIEW](https://github.com/kmuto/review)リポジトリをビルドしてPDFやEPUBを出力するための[GitHub Action](https://github.com/features/actions)です。Re:VIEW 5.9を使用しています。
 
 Re:VIEWファイルからPDFをビルドしてArtifactsとして保存できます。
 


### PR DESCRIPTION
Re:VIEW TemplateでRe:VIEWのサポートバージョンを5.9に上げたことに伴い、GitHub Actionsで使用するバージョンも5.9にしました。
https://github.com/TechBooster/ReVIEW-Template/pull/123